### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Node dependencies
+node_modules/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# System files
+.DS_Store
+Thumbs.db
+
+# Temporary files
+*.tmp
+*.temp
+*~
+
+# Build output
+/dist/
+/build/
+
+# Environment files
+.env


### PR DESCRIPTION
## Summary
- add a `.gitignore` to filter common artifacts like `node_modules/` and temporary files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884fe35a1f08325a6073c49bc994368