### PR TITLE
Remove contact and budget tabs from itinerary

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,9 +46,7 @@
 
             <div class="tabs">
                 <button class="tab-btn active" data-tab="schedule">スケジュール</button>
-                <button class="tab-btn" data-tab="contacts">連絡先</button>
                 <button class="tab-btn" data-tab="packing">持ち物</button>
-                <button class="tab-btn" data-tab="budget">費用</button>
                 <button class="tab-btn" data-tab="weather">天候対策</button>
             </div>
 
@@ -138,7 +136,7 @@
                                 <span class="time">17:30</span>
                                 <div class="activity">
                                     <strong>レストラン フレグラント</strong>
-                                    <p>信州牛しゃぶしゃぶコース</p>
+                                    <p>コース料理</p>
                                 </div>
                             </div>
                             <div class="schedule-item">
@@ -197,37 +195,6 @@
                     </div>
                 </div>
 
-                <!-- 連絡先タブ -->
-                <div id="contacts" class="tab-panel">
-                    <div class="contact-section">
-                        <h3>宿泊施設</h3>
-                        <div class="contact-item">
-                            <strong>蓼科東急ホテル</strong>
-                            <p>📞 0266-69-3109</p>
-                        </div>
-                        <div class="contact-item">
-                            <strong>東急ハーヴェストクラブ蓼科</strong>
-                            <p>📞 0266-60-2101</p>
-                        </div>
-                    </div>
-                    
-                    <div class="contact-section emergency">
-                        <h3>緊急連絡先</h3>
-                        <div class="contact-item">
-                            <strong>警察</strong>
-                            <p>📞 110</p>
-                        </div>
-                        <div class="contact-item">
-                            <strong>救急・消防</strong>
-                            <p>📞 119</p>
-                        </div>
-                        <div class="contact-item">
-                            <strong>諏訪中央病院</strong>
-                            <p>📞 0266-72-1000</p>
-                        </div>
-                    </div>
-                </div>
-
                 <!-- 持ち物タブ -->
                 <div id="packing" class="tab-panel">
                     <div class="packing-section">
@@ -257,38 +224,6 @@
                             <li>お菓子</li>
                             <li>飲み物</li>
                         </ul>
-                    </div>
-                </div>
-
-                <!-- 費用タブ -->
-                <div id="budget" class="tab-panel">
-                    <div class="budget-item">
-                        <span>交通費</span>
-                        <span>68,400円</span>
-                    </div>
-                    <div class="budget-item">
-                        <span>フィッシング</span>
-                        <span>8,500円</span>
-                    </div>
-                    <div class="budget-item">
-                        <span>クラフト体験</span>
-                        <span>12,000円</span>
-                    </div>
-                    <div class="budget-item">
-                        <span>BBQ</span>
-                        <span>24,000円</span>
-                    </div>
-                    <div class="budget-item">
-                        <span>スターウォッチング</span>
-                        <span>2,000円</span>
-                    </div>
-                    <div class="budget-item">
-                        <span>その他食事</span>
-                        <span>35,000円</span>
-                    </div>
-                    <div class="budget-item total">
-                        <span><strong>合計</strong></span>
-                        <span><strong>149,900円</strong></span>
                     </div>
                 </div>
 
@@ -412,8 +347,8 @@
                             <div class="kids-schedule-item">
                                 <span class="kids-time">17:30</span>
                                 <div class="kids-activity">
-                                    <strong>🥩 信州牛のしゃぶしゃぶ</strong>
-                                    <p>長野の美味しいお肉を食べよう！</p>
+                                    <strong>🍽️ コース料理</strong>
+                                    <p>みんなでゆったり食事を楽しもう！</p>
                                 </div>
                             </div>
                               <div class="kids-schedule-item highlight">


### PR DESCRIPTION
## Summary
- remove the contact and budget tabs from the adult itinerary view
- simplify the dinner course description to a generic course label in both adult and kids schedules

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925c9640d948325bcd845ea332d6b2f)